### PR TITLE
[LCSV-015] feat(llm): 클라이언트는 LLM 타입과 템플릿, 변수 목록, 시크릿 키를 전송해 LLM 서버를 이용할 수 있다

### DIFF
--- a/.env
+++ b/.env
@@ -1,3 +1,4 @@
 OPENAI_API_KEY=api-key
 NCP_CLOVASTUDIO_API_KEY=api-key
 NCP_APIGW_API_KEY=api-key
+SECRET_KEY=secret-key

--- a/app.py
+++ b/app.py
@@ -1,7 +1,10 @@
 import uvicorn
 from fastapi import FastAPI
 
+from routers import router
+
 app = FastAPI()
+app.include_router(router)
 
 if __name__ == "__main__":
     uvicorn.run(app, host="0.0.0.0", port=80)

--- a/llm_picker.py
+++ b/llm_picker.py
@@ -1,0 +1,16 @@
+from langchain_community.chat_models import ChatClovaX
+from langchain_ollama import ChatOllama
+from langchain_openai import ChatOpenAI
+
+DEFAULT_MODEL = ChatOllama(model="llama3.2")
+
+
+def get_llm(llm_type: str):
+    if llm_type == "clovax":
+        return ChatClovaX(model="HCX-003")
+    elif llm_type == "chatgpt":
+        return ChatOpenAI(temperature=0, model_name="gpt-3.5-turbo")
+    elif llm_type == "llama":
+        return ChatOllama(model="llama3.2")  # 기본 모델을 변경하더라도 함수가 변경에 닫혀 있도록 하기 위해 중복 설정
+    else:
+        return DEFAULT_MODEL

--- a/routers.py
+++ b/routers.py
@@ -1,0 +1,26 @@
+import os
+
+from dotenv import load_dotenv
+from fastapi import APIRouter
+from fastapi import HTTPException
+from pydantic import BaseModel
+
+from services import generate_response
+
+router = APIRouter()
+
+
+class LLMRequest(BaseModel):
+    llm_type: str
+    template: str
+    variables: str
+    secret_key: str
+
+
+@router.post("/")
+def invoke_llm(request: LLMRequest):
+    load_dotenv()
+    if request.secret_key != os.environ["SECRET_KEY"]:
+        raise HTTPException(status_code=401, detail="[인증 실패] Secret Key가 일치하지 않습니다. 확인 후 다시 시도해 주세요.")
+
+    return {"response": generate_response(request.llm_type, request.template, request.variables)}

--- a/services.py
+++ b/services.py
@@ -1,0 +1,15 @@
+from langchain_core.prompts import PromptTemplate
+
+from llm_picker import get_llm
+
+
+def generate_response(llm_type: str, template: str, variables: str):
+    prompt = PromptTemplate(
+        input_variables=["variables"],
+        template=template
+    )
+    llm = get_llm(llm_type)
+
+    chain = prompt | llm
+
+    return chain.invoke(input={"variables": variables})


### PR DESCRIPTION
## resolve [LCSV-015](https://langchain.atlassian.net/jira/software/projects/LCSV/list?selectedIssue=LCSV-15)
## resolve #2

## 작업내용
- LLM 타입과 템플릿, 변수를 통한 클라이언트 요청
- 클라이언트 시크릿 키 인증
- LLM 서비스 요청 비즈니스 로직
- 200 status code 응답