### PR TITLE
[LCSV-053] feat(llama): 클라이언트는 ChatOllama 대신 SambaNovaCloud를 통해 Llama3.3 모델 API를 사용할 수 있다

### DIFF
--- a/.env
+++ b/.env
@@ -4,3 +4,4 @@ NCP_APIGW_API_KEY=api-key
 SECRET_KEY=secret-key
 FRONTEND_URL=frontend-url
 GOOGLE_API_KEY=api-key
+SAMBANOVA_API_KEY=api-key

--- a/llm_picker.py
+++ b/llm_picker.py
@@ -1,14 +1,26 @@
 from langchain_community.chat_models import ChatClovaX
+from langchain_community.llms.sambanova import SambaNovaCloud
 from langchain_google_genai import ChatGoogleGenerativeAI
-from langchain_ollama import ChatOllama
 from langchain_openai import ChatOpenAI
 
-DEFAULT_MODEL = ChatClovaX(model="HCX-003", disable_streaming=False)
+DEFAULT_MODEL = SambaNovaCloud(
+    model="Meta-Llama-3.3-70B-Instruct",
+    max_tokens=1024,
+    temperature=0.7,
+    top_p=0.9,
+    top_k=40
+)
 
 
 def get_llm(llm_type: str):
-    if llm_type == "llama":
-        return ChatOllama(model="llama3.2", disable_streaming=False)
+    if llm_type == "llama":  # 기본 모델을 변경하더라도 함수가 변경에 닫혀 있도록 하기 위해 중복 설정
+        return SambaNovaCloud(
+            model="Meta-Llama-3.3-70B-Instruct",
+            max_tokens=1024,
+            temperature=0.7,
+            top_p=0.9,
+            top_k=40
+        )
     elif llm_type == "chatgpt":
         return ChatOpenAI(temperature=0, model_name="gpt-3.5-turbo", streaming=True)
     elif llm_type == "gemini":
@@ -18,6 +30,6 @@ def get_llm(llm_type: str):
             max_output_tokens=200
         )
     elif llm_type == "clovax":
-        return ChatClovaX(model="HCX-003", disable_streaming=False)  # 기본 모델을 변경하더라도 함수가 변경에 닫혀 있도록 하기 위해 중복 설정
+        return ChatClovaX(model="HCX-003", disable_streaming=False)
     else:
         return DEFAULT_MODEL


### PR DESCRIPTION
## resolve [LCSV-053](https://langchain.atlassian.net/browse/LCSV-53)
## resolve #28

## 작업내용
- API 키 발급
- SambaNovaCloud 패키지 설치
- Llama-3.3-70B-Instruct 모델 적용
- ChatOllama 패키지 제거
- ChatOllama 기반 Llama3.2 서비스 제거
- 기본 모델을 HCX-003에서 Llama3.3으로 변경